### PR TITLE
Improve accessibility titles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,3 +112,18 @@ a {
 section {
   scroll-margin-top: 4rem;
 }
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  z-index: 50;
+  transition: top 0.3s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,10 @@ import {
 } from "@/fonts/fonts";
 
 export const metadata: Metadata = {
-  title: "Tandem Creative Dev",
+  title: {
+    default: "Tandem Creative Dev",
+    template: "%s | Tandem Creative Dev",
+  },
   description:
     "Tandem is a creative development agency who prioritise human-centered design, based in London.",
 };
@@ -27,6 +30,7 @@ export default function RootLayout({
       className={`${diatypeRegular.variable} ${diatypeMedium.variable} ${diatypeMonoRegular.variable} ${diatypeMonoMedium.variable} ${diatypeCondensedMedium.variable} scroll-smooth`}
     >
       <body className="font-tandem-regular antialiased relative">
+        <a href="#main" className="skip-link">Skip to main content</a>
         <LoadingScreen />
         <Toaster position="bottom-center" />
         {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import AboutSection from "@/components/sections/About";
 import Header from "@/components/layout/Header";
 import Hero from "@/components/sections/Hero";
@@ -7,11 +8,15 @@ import TestimonialsSection from "@/components/sections/Testimonials";
 import TeamSection from "@/components/sections/Team";
 import FooterSection from "@/components/layout/Footer";
 import ContactSection from "@/components/sections/Contact";
+
+export const metadata: Metadata = {
+  title: "Home",
+};
 export default function HeroPage() {
   return (
     <>
       <Header />
-      <main>
+      <main id="main">
         <Hero />
         <AboutSection />
         <ServicesSection />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,9 +9,6 @@ import TeamSection from "@/components/sections/Team";
 import FooterSection from "@/components/layout/Footer";
 import ContactSection from "@/components/sections/Contact";
 
-export const metadata: Metadata = {
-  title: "Home",
-};
 export default function HeroPage() {
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import AboutSection from "@/components/sections/About";
 import Header from "@/components/layout/Header";
 import Hero from "@/components/sections/Hero";

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,8 +1,13 @@
+import type { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+};
 
 export default function PrivacyPolicy() {
   return (
-    <main className="max-w-3xl mx-auto px-6 py-12 text-gray-800">
+    <main id="main" className="max-w-3xl mx-auto px-6 py-12 text-gray-800">
       <h1 className="font-tandem-mono-medium uppercase text-3xl font-bold text-center mb-6">
         Privacy Policy
       </h1>


### PR DESCRIPTION
## Summary
- add page title template and skip link
- give pages a main element id and per-page titles

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685478ab6474832a88b1ae5780f82161