### PR TITLE
Fix/eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,13 +1,4 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-});
+import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 
 const eslintConfig = [
   {
@@ -26,7 +17,7 @@ const eslintConfig = [
       "yarn.lock",
     ],
   },
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...nextCoreWebVitals,
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -51,10 +51,9 @@
       "fast-xml-parser@>=5.0.9 <=5.3.3": ">=5.3.4",
       "minimatch@3": ">=3.1.4",
       "minimatch@9": "9.0.7",
-      "ajv@6": ">=6.14.0",
-      "ajv@8": "8.18.0",
-      "@eslint/eslintrc>minimatch": "9.0.7",
-      "@eslint/eslintrc>ajv": "8.18.0",
+      "@eslint/eslintrc>minimatch": "^3.1.5",
+      "@eslint/eslintrc>ajv": "^6.14.0",
+      "eslint>ajv": "^6.14.0",
       "fast-xml-parser": ">=5.3.8",
       "flatted@<3.4.0": ">=3.4.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,10 +13,9 @@ overrides:
   fast-xml-parser@>=5.0.9 <=5.3.3: '>=5.3.4'
   minimatch@3: '>=3.1.4'
   minimatch@9: 9.0.7
-  ajv@6: '>=6.14.0'
-  ajv@8: 8.18.0
-  '@eslint/eslintrc>minimatch': 9.0.7
-  '@eslint/eslintrc>ajv': 8.18.0
+  '@eslint/eslintrc>minimatch': ^3.1.5
+  '@eslint/eslintrc>ajv': ^6.14.0
+  eslint>ajv: ^6.14.0
   fast-xml-parser: '>=5.3.8'
   flatted@<3.4.0: '>=3.4.0'
 
@@ -1157,6 +1156,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -1239,6 +1241,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1264,6 +1269,9 @@ packages:
 
   bowser@2.13.1:
     resolution: {integrity: sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -1349,6 +1357,9 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   conventional-changelog-angular@7.0.0:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
@@ -1661,6 +1672,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
@@ -2058,6 +2072,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -2191,9 +2208,8 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
-  minimatch@9.0.7:
-    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -2445,6 +2461,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2830,6 +2850,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -3640,14 +3663,14 @@ snapshots:
 
   '@eslint/eslintrc@3.3.5':
     dependencies:
-      ajv: 8.18.0
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 9.0.7
+      minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4418,6 +4441,13 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4525,6 +4555,8 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -4540,6 +4572,11 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   bowser@2.13.1: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.4:
     dependencies:
@@ -4632,6 +4669,8 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
+
+  concat-map@0.0.1: {}
 
   conventional-changelog-angular@7.0.0:
     dependencies:
@@ -5029,7 +5068,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 8.18.0
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -5091,6 +5130,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
@@ -5473,6 +5514,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -5582,9 +5625,9 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
-  minimatch@9.0.7:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
 
@@ -5820,6 +5863,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -6334,6 +6379,10 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:

--- a/src/components/sections/NodeGraph/index.tsx
+++ b/src/components/sections/NodeGraph/index.tsx
@@ -12,7 +12,11 @@ interface NodeGraphProps {
 
 export default function NodeGraph({ seed }: NodeGraphProps) {
   const [isMobile, setIsMobile] = useState(false);
-  const [reducedMotion, setReducedMotion] = useState(false);
+  const [reducedMotion, setReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
@@ -23,7 +27,6 @@ export default function NodeGraph({ seed }: NodeGraphProps) {
 
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReducedMotion(mq.matches);
     const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -14,7 +14,10 @@ export default function ProjectsSection() {
   const [selectedProject, setSelectedProject] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
-  const [projectAnnouncement, setProjectAnnouncement] = useState('');
+  const projectAnnouncement =
+    selectedProject >= 0
+      ? `Now viewing ${projects[selectedProject].title}`
+      : "";
 
   const openModal = () => {
     setIsModalOpen(true);
@@ -28,12 +31,6 @@ export default function ProjectsSection() {
       setModalVisible(false);
     }, 300);
   }, []);
-
-  useEffect(() => {
-    if (selectedProject >= 0) {
-      setProjectAnnouncement(`Now viewing ${projects[selectedProject].title}`);
-    }
-  }, [selectedProject]);
 
   useEffect(() => {
     if (isModalOpen) {

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -23,11 +23,14 @@ export default function Checkbox({
   urlText,
   required = false,
 }: CheckboxProps) {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setPrefersReducedMotion(mediaQuery.matches);
 
     const handleChange = (event: MediaQueryListEvent) => {
       setPrefersReducedMotion(event.matches);

--- a/src/components/ui/ProjectModal.tsx
+++ b/src/components/ui/ProjectModal.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useCallback } from "react";
-import FocusTrap from "focus-trap-react";
+import { useEffect, useState, useCallback } from "react";
+import { FocusTrap } from "focus-trap-react";
 import UrlButton from "./UrlButton";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
@@ -26,7 +26,8 @@ export default function ProjectModal({
   const baseClasses =
     "absolute left-1/2 top-1/2 transform -translate-x-1/2 origin-center bg-white h-[1px] w-3 transition-all motion-reduce:transition-none duration-500 ease-in-out bg-white group-hover:bg-zinc-950/90";
 
-  const [isClosing, setIsClosing] = useState(false);
+  const [isClosingState, setIsClosing] = useState(false);
+  const isClosing = isOpen ? false : isClosingState;
   const modalClasses = clsx(
     "relative bg-zinc-950/90 rounded-xl overflow-hidden backdrop-blur-lg",
     "w-11/12 md:w-9/12 lg:w-7/12 max-h-[85vh] p-8 shadow-glow shadow-zinc-900",
@@ -52,7 +53,6 @@ export default function ProjectModal({
 
     if (isOpen) {
       document.addEventListener("keydown", handleEscape);
-      setIsClosing(false);
     }
 
     return () => {
@@ -88,7 +88,7 @@ export default function ProjectModal({
           "motion-reduce:transition-none motion-reduce:backdrop-blur-sm",
           isClosing
             ? "opacity-0 backdrop-blur-none"
-            : "opacity-100 backdrop-blur-sm"
+            : "opacity-100 backdrop-blur-sm",
         )}
         aria-hidden="true"
         onClick={handleClose}
@@ -103,54 +103,54 @@ export default function ProjectModal({
         }}
       >
         <div className={modalClasses}>
-        <div className="flex justify-between">
-          <h2 className="text-white text-3xl uppercase mb-8 font-tandem-condensed-medium truncate">
-            {title}
-          </h2>
-          <div className="flex-shrink-0">
-            <button
-              className="group relative flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-transparent border-[0.75px] hover:bg-white hover:text-zinc-950/90"
-              onClick={handleClose}
-              aria-label="Close modal"
-            >
-              <div
-                className={twMerge(baseClasses, "group-hover:rotate-45")}
-              ></div>
-              <div
-                className={twMerge(baseClasses, "group-hover:-rotate-45")}
-              ></div>
-            </button>
-          </div>
-        </div>
-
-        <p className="text-zinc-300 mb-6 text-lg">{description}</p>
-
-        <div className="mb-8">
-          {services.map((service, index) => (
-            <div key={index} className="flex items-center mb-2">
-              <div className="w-3 h-3 bg-zinc-500 rounded-sm mr-4"></div>
-              <span className="text-zinc-300 uppercase">{service}</span>
+          <div className="flex justify-between">
+            <h2 className="text-white text-3xl uppercase mb-8 font-tandem-condensed-medium truncate">
+              {title}
+            </h2>
+            <div className="flex-shrink-0">
+              <button
+                className="group relative flex-shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-transparent border-[0.75px] hover:bg-white hover:text-zinc-950/90"
+                onClick={handleClose}
+                aria-label="Close modal"
+              >
+                <div
+                  className={twMerge(baseClasses, "group-hover:rotate-45")}
+                ></div>
+                <div
+                  className={twMerge(baseClasses, "group-hover:-rotate-45")}
+                ></div>
+              </button>
             </div>
-          ))}
-        </div>
+          </div>
 
-        <div>
-          {websiteUrl && (
-            <UrlButton
-              label="Visit Website"
-              url={websiteUrl}
-              project={title}
-              className="mb-4 md:mb-0"
-            />
-          )}
-          {githubUrl && (
-            <UrlButton
-              label="Inspect Code Repo"
-              url={githubUrl}
-              project={title}
-            />
-          )}
-        </div>
+          <p className="text-zinc-300 mb-6 text-lg">{description}</p>
+
+          <div className="mb-8">
+            {services.map((service, index) => (
+              <div key={index} className="flex items-center mb-2">
+                <div className="w-3 h-3 bg-zinc-500 rounded-sm mr-4"></div>
+                <span className="text-zinc-300 uppercase">{service}</span>
+              </div>
+            ))}
+          </div>
+
+          <div>
+            {websiteUrl && (
+              <UrlButton
+                label="Visit Website"
+                url={websiteUrl}
+                project={title}
+                className="mb-4 md:mb-0"
+              />
+            )}
+            {githubUrl && (
+              <UrlButton
+                label="Inspect Code Repo"
+                url={githubUrl}
+                project={title}
+              />
+            )}
+          </div>
         </div>
       </FocusTrap>
     </div>

--- a/src/components/ui/Time.tsx
+++ b/src/components/ui/Time.tsx
@@ -1,93 +1,24 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import stateCapitals from "@/data/state_capitals.json";
-import countryCapitals from "@/data/country_capitals.json";
-import {
-  getTimezoneForLocation,
-  formatTimeForTimezone,
-} from "@/utils/timezoneHelper";
-
-const DEFAULT_TIMEZONE = "Europe/London";
+import { formatTimeForTimezone } from "@/utils/timezoneHelper";
 
 export default function Time() {
   const [currentTime, setCurrentTime] = useState<string>("");
-  const [location, setLocation] = useState<string>("");
-  const [isClient, setIsClient] = useState(false);
-  const [timezone, setTimezone] = useState<string>(DEFAULT_TIMEZONE);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    setIsClient(true);
-  }, []);
-
-  useEffect(() => {
-    if (!isClient) return;
-
-    const fetchLocationData = async () => {
-      try {
-        const response = await fetch("https://geolocation-db.com/json/");
-
-        if (!response.ok) {
-          throw new Error(`API responded with status: ${response.status}`);
-        }
-
-        const data = await response.json();
-
-        let detectedLocation = "London";
-
-        if (data.country_code === "US" && data.state) {
-          const stateKey = data.state as keyof typeof stateCapitals;
-          if (stateCapitals[stateKey]) {
-            detectedLocation = stateCapitals[stateKey];
-          } else {
-            console.warn(`State capital not found for: ${data.state}`);
-          }
-        } else if (data.country_name) {
-          const countryKey = data.country_name as keyof typeof countryCapitals;
-          if (countryCapitals[countryKey]) {
-            detectedLocation = countryCapitals[countryKey];
-          } else {
-            console.warn(`Country capital not found for: ${data.country_name}`);
-          }
-        }
-
-        setLocation(detectedLocation);
-
-        const detectedTimezone = getTimezoneForLocation(detectedLocation);
-        setTimezone(detectedTimezone);
-        console.log(
-          `Location: ${detectedLocation}, Timezone: ${detectedTimezone}`
-        );
-
-        if (data.error) {
-          setError(data.error);
-          console.warn("Location data warning:", data.error);
-        }
-      } catch (err) {
-        console.error("Failed to fetch location data:", err);
-        setError("Failed to load location data");
-        setLocation("London");
-        setTimezone(DEFAULT_TIMEZONE);
-      }
-    };
-
-    fetchLocationData();
-
     const interval = setInterval(() => {
       const now = new Date();
-      const formattedTime = formatTimeForTimezone(now, timezone);
-      setCurrentTime(formattedTime);
+      setCurrentTime(formatTimeForTimezone(now, "Europe/London"));
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [timezone, isClient]);
+  }, []);
 
   return (
     <div className="flex justify-start gap-5">
-      <p>{location}</p>
+      <p>London</p>
       <p>{currentTime}</p>
-      {error && <p className="text-red-500 text-xs hidden">Error: {error}</p>}
     </div>
   );
 }


### PR DESCRIPTION
- security fixes had broken linter by upgrading to eslint-next-config 16 - solution was to swap out FlatCompat + old config for a new  flat import in eslint.config.ts
- eslint-plugin-react-hooks flagged a whole bunch of linting errors in useState and useEffect hooks with the new refs and set-state-in-effect rules (fixed these issues now)
- got rid of geolocation feature on clock - now always set to London - the point is to signal where we are not to signal that we know where the user is