### PR TITLE
Feat/google reviews

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import LogoBanner from "@/components/sections/LogoBanner";
 import ServicesSection from "@/components/sections/Services";
 import ProjectsSection from "@/components/sections/Projects";
 import TestimonialsSection from "@/components/sections/Testimonials";
+import ReviewsSection from "@/components/sections/Reviews";
 import TeamSection from "@/components/sections/Team";
 import FooterSection from "@/components/layout/Footer";
 import ContactSection from "@/components/sections/Contact";
@@ -17,6 +18,7 @@ export default function HeroPage() {
         <Hero />
         <AboutSection />
         <LogoBanner />
+        <ReviewsSection />
         <ProjectsSection />
         <ServicesSection />
         <TestimonialsSection />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -87,7 +87,8 @@ export default function Header() {
             href={"#home"}
             onClick={() => setIsOpen(false)}
           >
-            <h1 className="text-center flex gap-1 group">
+            <h1 className="relative text-center flex gap-1 group">
+              {!isOpen && <div className="absolute inset-0 -m-6 rounded-full bg-black/95 blur-2xl -z-10" aria-hidden="true" />}
               <span className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
                 &lt;
               </span>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -87,8 +87,7 @@ export default function Header() {
             href={"#home"}
             onClick={() => setIsOpen(false)}
           >
-            <h1 className="relative text-center flex gap-1 group">
-              {!isOpen && <div className="absolute inset-0 -m-6 rounded-full bg-black/95 blur-2xl -z-10" aria-hidden="true" />}
+            <h1 className="text-center flex gap-1 group">
               <span className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
                 &lt;
               </span>

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -11,6 +11,7 @@ export default function Nav({ setIsOpen }: NavProps) {
         className="flex flex-col gap-4 xl:flex-row"
         onClick={() => setIsOpen(false)}
         padded
+        ctaContact
       />
     </nav>
   );

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import dynamic from "next/dynamic";
+import Link from "next/link";
 import nav_items from "@/data/nav_items.json";
 
 const NodeGraph = dynamic(() => import("./NodeGraph"), { ssr: false });
@@ -30,6 +31,13 @@ export default function Hero() {
             End to end full-stack development and AI engineering
           </span>
         </div>
+        <Link
+          href="#contact"
+          onClick={(e) => e.stopPropagation()}
+          className="relative pointer-events-auto mt-10 bg-white px-8 py-3 font-tandem-mono-regular text-sm uppercase text-black transition-colors hover:bg-gray-100"
+        >
+          Get in touch
+        </Link>
       </div>
     </section>
   );

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -21,9 +21,24 @@ export default function Hero() {
         <NodeGraph seed={seed} />
       </div>
       <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-black to-transparent pointer-events-none z-10" />
+      <Link
+        href="#reviews"
+        onClick={(e) => e.stopPropagation()}
+        className="absolute bottom-8 right-8 z-20 flex flex-col items-end gap-1 border border-white/40 px-4 py-3 text-white transition-colors hover:border-white/70 hover:text-white/70"
+      >
+        <span className="text-sm tracking-widest" aria-hidden="true">
+          ★★★★★
+        </span>
+        <span className="font-tandem-mono-regular text-xs uppercase tracking-widest">
+          5.0 · Google
+        </span>
+      </Link>
       <div className="relative z-10 h-screen flex flex-col justify-center items-center pointer-events-none">
         <div className="relative flex flex-col items-center">
-          <div className="absolute inset-0 -m-16 rounded-full bg-black/80 blur-3xl" aria-hidden="true" />
+          <div
+            className="absolute inset-0 -m-16 rounded-full bg-black/80 blur-3xl"
+            aria-hidden="true"
+          />
           <span className="relative pointer-events-auto text-white text-7xl max-w-[1000px] text-pretty text-center uppercase font-tandem-condensed-medium leading-tight">
             From discovery to deployment, <br /> we run in tandem with you
           </span>

--- a/src/components/sections/LogoBanner.tsx
+++ b/src/components/sections/LogoBanner.tsx
@@ -63,7 +63,7 @@ function LogoRow({ logos }: { logos: Logo[] }) {
 
 export default function LogoBanner() {
   return (
-    <section className="px-10 py-8">
+    <section className="px-10 pt-8 pb-12">
       <h2 className="font-tandem-mono-medium text-xs uppercase text-black text-center mb-6">
         Trusted by
       </h2>

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -55,18 +55,21 @@ export default function ReviewsSection() {
     <section className="border-y border-black overflow-hidden">
       <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
         <h2 className="col-span-2 col-start-3 font-tandem-mono-medium text-xs uppercase">
-          ■ Reviews
+          <span aria-hidden="true">■ </span>Reviews
         </h2>
         <div className="col-span-4 col-start-5 flex flex-col gap-3">
           <div className="flex items-end gap-5">
-            <span className="font-tandem-condensed-medium text-7xl leading-none">
+            <span
+              className="font-tandem-condensed-medium text-7xl leading-none"
+              aria-hidden="true"
+            >
               {OVERALL_RATING.toFixed(1)}
             </span>
             <div className="flex flex-col gap-1 pb-1">
               <div
                 className="flex gap-0.5"
                 role="img"
-                aria-label={`${OVERALL_RATING} out of 5 stars`}
+                aria-label={`Rated ${OVERALL_RATING} out of 5 stars on Google`}
               >
                 {Array.from({ length: 5 }).map((_, i) => (
                   <span
@@ -86,9 +89,19 @@ export default function ReviewsSection() {
         </div>
       </div>
 
+      <ul className="sr-only">
+        {reviews.map((review) => (
+          <li key={review.reviewer}>
+            <p>{review.reviewer} — {review.rating} out of 5 stars</p>
+            <blockquote>{review.content}</blockquote>
+            <time dateTime={review.date}>{timeAgo(review.date)}</time>
+          </li>
+        ))}
+      </ul>
+
       <div className="overflow-hidden pb-16 md:pb-24">
         <div className="flex w-max animate-marquee" style={{ animationDuration: "40s" }} aria-hidden="true">
-          {[reviews, reviews].map((set, s) => (
+          {[reviews, reviews, reviews, reviews].map((set, s) => (
             <div key={s} className="flex gap-6 mr-6">
               {set.map((review, i) => (
                 <ReviewCard
@@ -98,6 +111,7 @@ export default function ReviewsSection() {
                   rating={review.rating}
                   content={review.content}
                   timeAgo={timeAgo(review.date)}
+                  date={review.date}
                 />
               ))}
             </div>

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -1,37 +1,49 @@
 import ReviewCard from "@/components/ui/ReviewCard";
 
+function timeAgo(date: string): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  if (days < 7) return `${days} day${days !== 1 ? "s" : ""} ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks} week${weeks !== 1 ? "s" : ""} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} month${months !== 1 ? "s" : ""} ago`;
+  const years = Math.floor(days / 365);
+  return `${years} year${years !== 1 ? "s" : ""} ago`;
+}
+
 const reviews = [
   {
     reviewer: "Joseph Flynn",
     initials: "JF",
     rating: 5,
+    date: "2026-04-21",
     content:
       "Jack and Max are both brilliant and highly productive developers with a lot of experience. They are both very friendly and supportive, professionally and personally. I would highly recommend working with them if you're looking for talented developers. Would give more stars if possible!",
-    timeAgo: "1 month ago",
   },
   {
     reviewer: "Jaz Maslen",
     initials: "JM",
     rating: 5,
+    date: "2026-04-30",
     content:
       "I went to some summer workshops on Claude Code that Jack and Max ran. They were some of the most productive and informative workshops I've been to — plus super hands on!",
-    timeAgo: "3 weeks ago",
   },
   {
     reviewer: "Dan Sofer",
     initials: "DS",
     rating: 5,
+    date: "2026-03-21",
     content:
       "I've worked with Jack and Max at Tandem. I highly recommend them.",
-    timeAgo: "2 months ago",
   },
   {
     reviewer: "Lucy Paul",
     initials: "LP",
     rating: 5,
+    date: "2026-03-21",
     content:
       "These guys are superb to work with. Brilliant at interpreting our brief. Brought new ideas to the design. Informative, creative and responsive. Highly recommend. Was such a pleasure working with Max.",
-    timeAgo: "2 months ago",
   },
 ];
 
@@ -39,8 +51,6 @@ const OVERALL_RATING = 5.0;
 const REVIEW_COUNT = reviews.length;
 
 export default function ReviewsSection() {
-  const doubled = [...reviews, ...reviews];
-
   return (
     <section className="border-y border-black overflow-hidden">
       <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
@@ -77,12 +87,20 @@ export default function ReviewsSection() {
       </div>
 
       <div className="overflow-hidden pb-16 md:pb-24">
-        <div
-          className="flex w-max animate-marquee gap-6"
-          aria-hidden="true"
-        >
-          {doubled.map((review, i) => (
-            <ReviewCard key={i} {...review} />
+        <div className="flex w-max animate-marquee" style={{ animationDuration: "40s" }} aria-hidden="true">
+          {[reviews, reviews].map((set, s) => (
+            <div key={s} className="flex gap-6 mr-6">
+              {set.map((review, i) => (
+                <ReviewCard
+                  key={i}
+                  reviewer={review.reviewer}
+                  initials={review.initials}
+                  rating={review.rating}
+                  content={review.content}
+                  timeAgo={timeAgo(review.date)}
+                />
+              ))}
+            </div>
           ))}
         </div>
       </div>

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -81,9 +81,14 @@ export default function ReviewsSection() {
                   </span>
                 ))}
               </div>
-              <span className="font-tandem-mono-regular text-xs uppercase text-gray-500">
-                {REVIEW_COUNT} reviews · Google
-              </span>
+              <a
+                href="https://share.google/i6GRxFpwXWs5tM7EZ"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-tandem-mono-regular text-xs uppercase text-gray-500 hover:text-black transition-colors"
+              >
+                {REVIEW_COUNT} reviews · <span className="underline">Google</span> ↗
+              </a>
             </div>
           </div>
         </div>

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -48,48 +48,45 @@ const reviews = [
 ];
 
 const OVERALL_RATING = 5.0;
-const REVIEW_COUNT = reviews.length;
 
 export default function ReviewsSection() {
   return (
-    <section className="border-y border-black overflow-hidden">
+    <section className="overflow-hidden border-y border-black pb-16 md:pb-24">
       <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
         <h2 className="col-span-2 col-start-3 font-tandem-mono-medium text-xs uppercase">
           <span aria-hidden="true">■ </span>Reviews
         </h2>
-        <div className="col-span-4 col-start-5 flex flex-col gap-3">
-          <div className="flex items-end gap-5">
-            <span
-              className="font-tandem-condensed-medium text-7xl leading-none"
-              aria-hidden="true"
+        <div className="col-span-4 col-start-5 flex items-end gap-5">
+          <span
+            className="font-tandem-condensed-medium text-7xl leading-none"
+            aria-hidden="true"
+          >
+            {OVERALL_RATING.toFixed(1)}
+          </span>
+          <div className="flex flex-col gap-1 pb-1">
+            <div
+              className="flex gap-0.5"
+              role="img"
+              aria-label={`Rated ${OVERALL_RATING} out of 5 stars on Google`}
             >
-              {OVERALL_RATING.toFixed(1)}
-            </span>
-            <div className="flex flex-col gap-1 pb-1">
-              <div
-                className="flex gap-0.5"
-                role="img"
-                aria-label={`Rated ${OVERALL_RATING} out of 5 stars on Google`}
-              >
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <span
-                    key={i}
-                    aria-hidden="true"
-                    className="text-2xl leading-none text-black"
-                  >
-                    ★
-                  </span>
-                ))}
-              </div>
-              <a
-                href="https://share.google/i6GRxFpwXWs5tM7EZ"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-tandem-mono-regular text-xs uppercase text-gray-500 hover:text-black transition-colors"
-              >
-                {REVIEW_COUNT} reviews · <span className="underline">Google</span> ↗
-              </a>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <span
+                  key={i}
+                  aria-hidden="true"
+                  className="text-2xl leading-none text-black"
+                >
+                  ★
+                </span>
+              ))}
             </div>
+            <a
+              href="https://share.google/i6GRxFpwXWs5tM7EZ"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-tandem-mono-regular text-xs uppercase text-gray-500 transition-colors hover:text-black"
+            >
+              {reviews.length} reviews · <span className="underline">Google</span> ↗
+            </a>
           </div>
         </div>
       </div>
@@ -104,24 +101,26 @@ export default function ReviewsSection() {
         ))}
       </ul>
 
-      <div className="overflow-hidden pb-16 md:pb-24">
-        <div className="flex w-max animate-marquee" style={{ animationDuration: "40s" }} aria-hidden="true">
-          {[reviews, reviews, reviews, reviews].map((set, s) => (
-            <div key={s} className="flex gap-6 mr-6">
-              {set.map((review, i) => (
-                <ReviewCard
-                  key={i}
-                  reviewer={review.reviewer}
-                  initials={review.initials}
-                  rating={review.rating}
-                  content={review.content}
-                  timeAgo={timeAgo(review.date)}
-                  date={review.date}
-                />
-              ))}
-            </div>
-          ))}
-        </div>
+      <div
+        className="flex w-max animate-marquee"
+        style={{ animationDuration: "40s" }}
+        aria-hidden="true"
+      >
+        {([reviews, reviews, reviews, reviews]).map((set, s) => (
+          <div key={s} className="flex gap-6 mr-6">
+            {set.map((review, i) => (
+              <ReviewCard
+                key={i}
+                reviewer={review.reviewer}
+                initials={review.initials}
+                rating={review.rating}
+                content={review.content}
+                timeAgo={timeAgo(review.date)}
+                date={review.date}
+              />
+            ))}
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -51,7 +51,7 @@ const OVERALL_RATING = 5.0;
 
 export default function ReviewsSection() {
   return (
-    <section className="overflow-hidden border-y border-black pb-16 md:pb-24">
+    <section id="reviews" className="overflow-hidden border-y border-black pb-16 md:pb-24">
       <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
         <h2 className="col-span-2 col-start-3 font-tandem-mono-medium text-xs uppercase">
           <span aria-hidden="true">■ </span>Reviews

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -1,0 +1,91 @@
+import ReviewCard from "@/components/ui/ReviewCard";
+
+const reviews = [
+  {
+    reviewer: "Joseph Flynn",
+    initials: "JF",
+    rating: 5,
+    content:
+      "Jack and Max are both brilliant and highly productive developers with a lot of experience. They are both very friendly and supportive, professionally and personally. I would highly recommend working with them if you're looking for talented developers. Would give more stars if possible!",
+    timeAgo: "1 month ago",
+  },
+  {
+    reviewer: "Jaz Maslen",
+    initials: "JM",
+    rating: 5,
+    content:
+      "I went to some summer workshops on Claude Code that Jack and Max ran. They were some of the most productive and informative workshops I've been to — plus super hands on!",
+    timeAgo: "3 weeks ago",
+  },
+  {
+    reviewer: "Dan Sofer",
+    initials: "DS",
+    rating: 5,
+    content:
+      "I've worked with Jack and Max at Tandem. I highly recommend them.",
+    timeAgo: "2 months ago",
+  },
+  {
+    reviewer: "Lucy Paul",
+    initials: "LP",
+    rating: 5,
+    content:
+      "These guys are superb to work with. Brilliant at interpreting our brief. Brought new ideas to the design. Informative, creative and responsive. Highly recommend. Was such a pleasure working with Max.",
+    timeAgo: "2 months ago",
+  },
+];
+
+const OVERALL_RATING = 5.0;
+const REVIEW_COUNT = reviews.length;
+
+export default function ReviewsSection() {
+  const doubled = [...reviews, ...reviews];
+
+  return (
+    <section className="border-y border-black overflow-hidden">
+      <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
+        <h2 className="col-span-2 col-start-3 font-tandem-mono-medium text-xs uppercase">
+          ■ Reviews
+        </h2>
+        <div className="col-span-4 col-start-5 flex flex-col gap-3">
+          <div className="flex items-end gap-5">
+            <span className="font-tandem-condensed-medium text-7xl leading-none">
+              {OVERALL_RATING.toFixed(1)}
+            </span>
+            <div className="flex flex-col gap-1 pb-1">
+              <div
+                className="flex gap-0.5"
+                role="img"
+                aria-label={`${OVERALL_RATING} out of 5 stars`}
+              >
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <span
+                    key={i}
+                    aria-hidden="true"
+                    className="text-2xl leading-none text-black"
+                  >
+                    ★
+                  </span>
+                ))}
+              </div>
+              <span className="font-tandem-mono-regular text-xs uppercase text-gray-500">
+                {REVIEW_COUNT} reviews · Google
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden pb-16 md:pb-24">
+        <div
+          className="flex w-max animate-marquee gap-6"
+          aria-hidden="true"
+        >
+          {doubled.map((review, i) => (
+            <ReviewCard key={i} {...review} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/ReviewCard.tsx
+++ b/src/components/ui/ReviewCard.tsx
@@ -3,6 +3,7 @@ interface ReviewCardProps {
   reviewer: string;
   rating: number;
   timeAgo?: string;
+  date?: string;
   initials: string;
 }
 
@@ -11,6 +12,7 @@ export default function ReviewCard({
   reviewer,
   rating,
   timeAgo,
+  date,
   initials,
 }: ReviewCardProps) {
   return (
@@ -51,7 +53,14 @@ export default function ReviewCard({
         </div>
         <div className="flex min-w-0 flex-col font-tandem-mono-medium uppercase">
           <p className="truncate text-sm">{reviewer}</p>
-          {timeAgo && <p className="text-xs text-gray-500">{timeAgo}</p>}
+          {timeAgo && (
+            <time
+              dateTime={date}
+              className="text-xs text-gray-500"
+            >
+              {timeAgo}
+            </time>
+          )}
         </div>
       </figcaption>
     </figure>

--- a/src/components/ui/ReviewCard.tsx
+++ b/src/components/ui/ReviewCard.tsx
@@ -1,0 +1,59 @@
+interface ReviewCardProps {
+  content: string;
+  reviewer: string;
+  rating: number;
+  timeAgo?: string;
+  initials: string;
+}
+
+export default function ReviewCard({
+  content,
+  reviewer,
+  rating,
+  timeAgo,
+  initials,
+}: ReviewCardProps) {
+  return (
+    <figure className="flex w-80 shrink-0 flex-col border border-black bg-white">
+      <div className="flex items-center justify-between border-b border-black px-5 py-4">
+        <div
+          className="flex gap-0.5"
+          role="img"
+          aria-label={`${rating} out of 5 stars`}
+        >
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span
+              key={i}
+              aria-hidden="true"
+              className={`text-lg leading-none ${i < rating ? "text-black" : "text-gray-300"}`}
+            >
+              ★
+            </span>
+          ))}
+        </div>
+        <span className="font-tandem-mono-regular text-xs uppercase tracking-widest text-gray-500">
+          Google
+        </span>
+      </div>
+      <blockquote className="flex-1 px-5 py-6">
+        <p className="font-tandem-regular text-sm leading-relaxed line-clamp-5">
+          &ldquo;{content}&rdquo;
+        </p>
+      </blockquote>
+      <figcaption className="flex items-center gap-4 border-t border-black px-5 py-4">
+        <div
+          aria-hidden="true"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-black text-white"
+        >
+          <span className="font-tandem-mono-medium text-xs uppercase">
+            {initials}
+          </span>
+        </div>
+        <div className="flex min-w-0 flex-col font-tandem-mono-medium uppercase">
+          <p className="truncate text-sm">{reviewer}</p>
+          {timeAgo && <p className="text-xs text-gray-500">{timeAgo}</p>}
+        </div>
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/ui/SectionLinks.tsx
+++ b/src/components/ui/SectionLinks.tsx
@@ -10,6 +10,7 @@ interface SectionLinksProps {
   startIndex?: number;
   onClick?: (isOpen: boolean) => void;
   padded?: boolean;
+  ctaContact?: boolean;
 }
 
 export default function SectionLinks({
@@ -17,6 +18,7 @@ export default function SectionLinks({
   startIndex = 1,
   onClick = () => {},
   padded = false,
+  ctaContact = false,
 }: SectionLinksProps) {
   return (
     <ul
@@ -29,7 +31,7 @@ export default function SectionLinks({
           className="relative list-none transition-all motion-reduce:transition-none duration-500 group-hover:text-gray-500 pointer-events-auto"
         >
           {index >= startIndex && (
-            item === "contact" ? (
+            item === "contact" && ctaContact ? (
               <Link
                 href="#contact"
                 aria-label="Scroll to contact"

--- a/src/components/ui/SectionLinks.tsx
+++ b/src/components/ui/SectionLinks.tsx
@@ -29,22 +29,33 @@ export default function SectionLinks({
           className="relative list-none transition-all motion-reduce:transition-none duration-500 group-hover:text-gray-500 pointer-events-auto"
         >
           {index >= startIndex && (
-            <Link
-              href={`#${item}`}
-              aria-label={`Scroll to ${item}`}
-              className={clsx(
-                `relative z-10
-                before:absolute before:top-0 before:left-0 before:w-full before:h-full
-                before:bg-white before:z-[-1] before:transition-transform motion-reduce:before:transition-none before:duration-500
-                before:origin-right before:scale-x-0 before:scale-y-75
-                hover:before:origin-left hover:before:scale-x-100 hover:!text-black
-                px-1`,
-                padded && "py-[2px]"
-              )}
-              onClick={() => onClick(false)}
-            >
-              {item}
-            </Link>
+            item === "contact" ? (
+              <Link
+                href="#contact"
+                aria-label="Scroll to contact"
+                className="bg-black px-3 py-0.5 text-white transition-colors hover:bg-gray-800 xl:bg-white xl:text-black xl:hover:bg-gray-100"
+                onClick={() => onClick(false)}
+              >
+                {item}
+              </Link>
+            ) : (
+              <Link
+                href={`#${item}`}
+                aria-label={`Scroll to ${item}`}
+                className={clsx(
+                  `relative z-10
+                  before:absolute before:top-0 before:left-0 before:w-full before:h-full
+                  before:bg-white before:z-[-1] before:transition-transform motion-reduce:before:transition-none before:duration-500
+                  before:origin-right before:scale-x-0 before:scale-y-75
+                  hover:before:origin-left hover:before:scale-x-100 hover:!text-black
+                  px-1`,
+                  padded && "py-[2px]"
+                )}
+                onClick={() => onClick(false)}
+              >
+                {item}
+              </Link>
+            )
           )}
         </li>
       ))}


### PR DESCRIPTION
Adds Google Reviews section and strengthens contact CTAs across hero and nav.

New `ReviewsSection` and `ReviewCard` components display 4 real reviews (Joseph Flynn, Jaz Maslen, Dan Sofer, Lucy Paul) in a continuous horizontal marquee. Header shows overall score, 5-star `role="img"` rating, and link to Google Reviews page. Cards use `<figure>`/`<blockquote>`/`<figcaption>` with `<time dateTime>` for timestamps — computed at render via `timeAgo()` from real ISO dates, not hardcoded strings. Marquee quadruplicates content to prevent viewport-width gaps. Entire track is `aria-hidden="true"`; a visually hidden `<ul>` serves screen readers. Inserted between `LogoBanner` and `ProjectsSection`.

Hero gained 2 CTAs. Solid white "Get in touch" button below subtitle links to `#contact`, positioned outside the blurred backdrop div. Bottom-right badge shows `★★★★★ / 5.0 · Google` at low opacity in a faint border box, links to `#reviews`. Both use `e.stopPropagation()` to avoid re-seeding the node graph.

`SectionLinks` gained `ctaContact` prop (default `false`). When true, renders "contact" as a filled block — `bg-black text-white` mobile, `bg-white text-black` desktop — instead of the sliding-underline animation. Passed only from `Nav`; footer unaffected.

No API calls, no data fetching, no schema changes. Review content is static.
