### PR TITLE
Feature/motion safe reviews

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,7 +36,14 @@
 
 button,
 a {
-  @apply focus:outline-none focus-visible:ring-2 focus:ring-blue-600 focus:ring-offset-1 focus:ring-offset-transparent transition-colors;
+  @apply focus:outline-none focus-visible:ring-2 focus:ring-blue-600 focus:ring-offset-1 focus:ring-offset-transparent;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  button,
+  a {
+    @apply transition-colors;
+  }
 }
 
 /* CHECKBOX STYLING - eventually would be nice to use tailwind */
@@ -72,7 +79,12 @@ a {
   outline: none;
   margin: 0;
   padding: 0;
-  transition: all calc(var(--dur) / 3) linear;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .checkbox-wrapper-30 .checkbox input {
+    transition: all calc(var(--dur) / 3) linear;
+  }
 }
 .checkbox-wrapper-30 .checkbox input:hover,
 .checkbox-wrapper-30 .checkbox input:checked {
@@ -100,7 +112,14 @@ a {
   stroke-linejoin: round;
   stroke-width: 2px;
   top: 0;
-  transition: stroke-dasharray var(--dur), stroke-dashoffset var(--dur);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .checkbox-wrapper-30 .checkbox svg {
+    transition:
+      stroke-dasharray var(--dur),
+      stroke-dashoffset var(--dur);
+  }
 }
 .checkbox-wrapper-30 .checkbox svg,
 .checkbox-wrapper-30 .checkbox input {
@@ -121,7 +140,12 @@ section {
   color: #fff;
   padding: 0.5rem 1rem;
   z-index: 50;
-  transition: top 0.3s ease;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .skip-link {
+    transition: top 0.3s ease;
+  }
 }
 
 .skip-link:focus {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -70,8 +70,9 @@ export default function Header() {
               ? "fixed top-0 left-0 bg-black pb-5"
               : "absolute top-0 left-0 bg-none"
           }
-          transition-all 
-          duration-300 
+          transition-all
+          duration-300
+          motion-reduce:transition-none
           z-50
         `}
       >
@@ -88,11 +89,11 @@ export default function Header() {
             onClick={() => setIsOpen(false)}
           >
             <h1 className="text-center flex gap-1 group">
-              <span className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
+              <span className="text-gray-400 opacity-0 group-hover:opacity-100 motion-safe:transition-opacity hidden md:block">
                 &lt;
               </span>
               tandem creative dev
-              <span className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity hidden md:block">
+              <span className="text-gray-400 opacity-0 group-hover:opacity-100 motion-safe:transition-opacity hidden md:block">
                 /&gt;
               </span>
             </h1>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -25,7 +25,7 @@ export default function Hero() {
       <Link
         href="#reviews"
         onClick={(e) => e.stopPropagation()}
-        className="absolute bottom-8 right-8 z-20 flex flex-col items-end gap-1 border border-white/40 px-4 py-3 text-white transition-colors hover:border-white/70 hover:text-white/70"
+        className="absolute bottom-8 right-8 z-20 flex flex-col items-end gap-1 border border-white/40 px-4 py-3 text-white motion-safe:transition-colors hover:border-white/70 hover:text-white/70"
       >
         <span className="text-sm tracking-widest" aria-hidden="true">
           ★★★★★

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import LinkButton from "@/components/ui/LinkButton";
 import nav_items from "@/data/nav_items.json";
 
 const NodeGraph = dynamic(() => import("./NodeGraph"), { ssr: false });
@@ -46,13 +47,13 @@ export default function Hero() {
             End to end full-stack development and AI engineering
           </span>
         </div>
-        <Link
+        <LinkButton
           href="#contact"
+          label="Get in touch"
+          ariaLabel="Scroll to contact"
           onClick={(e) => e.stopPropagation()}
-          className="relative pointer-events-auto mt-10 bg-white px-8 py-3 font-tandem-mono-regular text-sm uppercase text-black transition-colors hover:bg-gray-100"
-        >
-          Get in touch
-        </Link>
+          className="relative pointer-events-auto mt-10 px-8 py-3"
+        />
       </div>
     </section>
   );

--- a/src/components/sections/LogoBanner.tsx
+++ b/src/components/sections/LogoBanner.tsx
@@ -46,7 +46,7 @@ function LogoImage({ src, alt, height }: Logo) {
       height={height}
       width={200}
       style={{ objectFit: "contain", width: "auto", height: `${height}px` }}
-      className="grayscale hover:grayscale-0 transition-all duration-300"
+      className="grayscale hover:grayscale-0 motion-safe:transition-all motion-safe:duration-300"
     />
   );
 }

--- a/src/components/sections/NodeGraph/index.tsx
+++ b/src/components/sections/NodeGraph/index.tsx
@@ -32,7 +32,7 @@ export default function NodeGraph({ seed }: NodeGraphProps) {
   if (reducedMotion) return null;
 
   return (
-    <div className="w-full h-full animate-fade-in">
+    <div className="w-full h-full motion-safe:animate-fade-in">
       <Canvas
         flat
         camera={{ position: [0, 0, 18], fov: 70 }}

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -51,7 +51,10 @@ const OVERALL_RATING = 5.0;
 
 export default function ReviewsSection() {
   return (
-    <section id="reviews" className="overflow-hidden border-y border-black pb-16 md:pb-24">
+    <section
+      id="reviews"
+      className="overflow-hidden border-y border-black pb-16 md:pb-24"
+    >
       <div className="m-auto flex w-10/12 grid-cols-12 flex-col gap-6 py-16 md:py-24 lg:grid lg:w-full">
         <h2 className="col-span-2 col-start-3 font-tandem-mono-medium text-xs uppercase">
           <span aria-hidden="true">■ </span>Reviews
@@ -85,7 +88,8 @@ export default function ReviewsSection() {
               rel="noopener noreferrer"
               className="font-tandem-mono-regular text-xs uppercase text-gray-500 transition-colors hover:text-black"
             >
-              {reviews.length} reviews · <span className="underline">Google</span> ↗
+              {reviews.length} reviews ·{" "}
+              <span className="underline">Google</span> ↗
             </a>
           </div>
         </div>
@@ -94,33 +98,37 @@ export default function ReviewsSection() {
       <ul className="sr-only">
         {reviews.map((review) => (
           <li key={review.reviewer}>
-            <p>{review.reviewer} — {review.rating} out of 5 stars</p>
+            <p>
+              {review.reviewer} — {review.rating} out of 5 stars
+            </p>
             <blockquote>{review.content}</blockquote>
             <time dateTime={review.date}>{timeAgo(review.date)}</time>
           </li>
         ))}
       </ul>
 
-      <div
-        className="flex w-max motion-safe:animate-marquee"
-        style={{ animationDuration: "40s" }}
-        aria-hidden="true"
-      >
-        {([reviews, reviews, reviews, reviews]).map((set, s) => (
-          <div key={s} className="flex gap-6 mr-6">
-            {set.map((review, i) => (
-              <ReviewCard
-                key={i}
-                reviewer={review.reviewer}
-                initials={review.initials}
-                rating={review.rating}
-                content={review.content}
-                timeAgo={timeAgo(review.date)}
-                date={review.date}
-              />
-            ))}
-          </div>
-        ))}
+      <div className="flex justify-center">
+        <div
+          className="flex gap-6 w-max motion-safe:animate-marquee"
+          style={{ animationDuration: "40s" }}
+          aria-hidden="true"
+        >
+          {[reviews, reviews, reviews, reviews].map((set, s) => (
+            <div key={s} className="flex gap-6">
+              {set.map((review, i) => (
+                <ReviewCard
+                  key={i}
+                  reviewer={review.reviewer}
+                  initials={review.initials}
+                  rating={review.rating}
+                  content={review.content}
+                  timeAgo={timeAgo(review.date)}
+                  date={review.date}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -86,7 +86,7 @@ export default function ReviewsSection() {
               href="https://share.google/i6GRxFpwXWs5tM7EZ"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-tandem-mono-regular text-xs uppercase text-gray-500 transition-colors hover:text-black"
+              className="font-tandem-mono-regular text-xs uppercase text-gray-500 motion-safe:transition-colors hover:text-black"
             >
               {reviews.length} reviews ·{" "}
               <span className="underline">Google</span> ↗

--- a/src/components/sections/Reviews.tsx
+++ b/src/components/sections/Reviews.tsx
@@ -102,7 +102,7 @@ export default function ReviewsSection() {
       </ul>
 
       <div
-        className="flex w-max animate-marquee"
+        className="flex w-max motion-safe:animate-marquee"
         style={{ animationDuration: "40s" }}
         aria-hidden="true"
       >

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -14,7 +14,7 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const baseStyles =
-    "bg-black border-2 border-black px-3.5 py-3 min-h-[24px] text-center font-tandem-mono-regular text-sm font-semibold uppercase text-white shadow-sm hover:bg-white hover:text-black";
+    "bg-black border-2 border-black px-3.5 py-3 min-h-[24px] text-center font-tandem-mono-regular text-sm font-semibold uppercase text-white hover:bg-white hover:text-black";
   const widthStyles = fullWidth ? "w-full" : "";
 
   return (

--- a/src/components/ui/LinkButton.tsx
+++ b/src/components/ui/LinkButton.tsx
@@ -13,7 +13,7 @@ interface LinkButtonProps {
 export default function LinkButton({
   href,
   label,
-  className,
+  className = "text-sm",
   ariaLabel,
   onClick,
 }: LinkButtonProps) {
@@ -23,7 +23,7 @@ export default function LinkButton({
       aria-label={ariaLabel}
       onClick={onClick}
       className={twMerge(
-        "border-2 border-white bg-white font-tandem-mono-regular text-sm uppercase text-black motion-safe:transition-colors hover:bg-black hover:text-white",
+        "border-2 border-white bg-white font-tandem-mono-regular uppercase text-black motion-safe:transition-colors hover:bg-black hover:text-white",
         className,
       )}
     >

--- a/src/components/ui/LinkButton.tsx
+++ b/src/components/ui/LinkButton.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { ComponentProps } from "react";
+import { twMerge } from "tailwind-merge";
+
+interface LinkButtonProps {
+  href: string;
+  label: string;
+  className?: string;
+  ariaLabel?: string;
+  onClick?: ComponentProps<typeof Link>["onClick"];
+}
+
+export default function LinkButton({
+  href,
+  label,
+  className,
+  ariaLabel,
+  onClick,
+}: LinkButtonProps) {
+  return (
+    <Link
+      href={href}
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={twMerge(
+        "border-2 border-white bg-white font-tandem-mono-regular text-smfont-semibold uppercase text-black transition-colors hover:bg-black hover:text-white",
+        className,
+      )}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/src/components/ui/LinkButton.tsx
+++ b/src/components/ui/LinkButton.tsx
@@ -23,7 +23,7 @@ export default function LinkButton({
       aria-label={ariaLabel}
       onClick={onClick}
       className={twMerge(
-        "border-2 border-white bg-white font-tandem-mono-regular text-smfont-semibold uppercase text-black transition-colors hover:bg-black hover:text-white",
+        "border-2 border-white bg-white font-tandem-mono-regular text-sm uppercase text-black motion-safe:transition-colors hover:bg-black hover:text-white",
         className,
       )}
     >

--- a/src/components/ui/MobileProjectImages.tsx
+++ b/src/components/ui/MobileProjectImages.tsx
@@ -26,7 +26,7 @@ export default function MobileProjectImages({
                 setSelectedProject(index);
                 openModal();
               }}
-              className="uppercase text-2xl font-tandem-medium mb-2 text-left hover:text-gray-300 transition-colors"
+              className="uppercase text-2xl font-tandem-medium mb-2 text-left hover:text-gray-300 motion-safe:transition-colors"
             >
               {project.title}
             </button>

--- a/src/components/ui/SectionLinks.tsx
+++ b/src/components/ui/SectionLinks.tsx
@@ -37,7 +37,7 @@ export default function SectionLinks({
                 href="#contact"
                 label={item}
                 ariaLabel="Scroll to contact"
-                className="bg-black px-3 py-0.5 text-white hover:bg-white hover:text-black xl:bg-white xl:text-black xl:hover:bg-black xl:hover:text-white"
+                className="bg-black px-3 py-0.5 text-white hover:bg-white hover:text-black xl:text-sm xl:bg-white xl:text-black xl:hover:bg-black xl:hover:text-white"
                 onClick={() => onClick(false)}
               />
             ) : (

--- a/src/components/ui/SectionLinks.tsx
+++ b/src/components/ui/SectionLinks.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import LinkButton from "@/components/ui/LinkButton";
 import nav_items from "@/data/nav_items.json";
 import { twMerge } from "tailwind-merge";
 import clsx from "clsx";
@@ -30,16 +31,15 @@ export default function SectionLinks({
           key={index}
           className="relative list-none transition-all motion-reduce:transition-none duration-500 group-hover:text-gray-500 pointer-events-auto"
         >
-          {index >= startIndex && (
-            item === "contact" && ctaContact ? (
-              <Link
+          {index >= startIndex &&
+            (item === "contact" && ctaContact ? (
+              <LinkButton
                 href="#contact"
-                aria-label="Scroll to contact"
-                className="bg-black px-3 py-0.5 text-white transition-colors hover:bg-gray-800 xl:bg-white xl:text-black xl:hover:bg-gray-100"
+                label={item}
+                ariaLabel="Scroll to contact"
+                className="bg-black px-3 py-0.5 text-white hover:bg-white hover:text-black xl:bg-white xl:text-black xl:hover:bg-black xl:hover:text-white"
                 onClick={() => onClick(false)}
-              >
-                {item}
-              </Link>
+              />
             ) : (
               <Link
                 href={`#${item}`}
@@ -51,14 +51,13 @@ export default function SectionLinks({
                   before:origin-right before:scale-x-0 before:scale-y-75
                   hover:before:origin-left hover:before:scale-x-100 hover:!text-black
                   px-1`,
-                  padded && "py-[2px]"
+                  padded && "py-[2px]",
                 )}
                 onClick={() => onClick(false)}
               >
                 {item}
               </Link>
-            )
-          )}
+            ))}
         </li>
       ))}
     </ul>

--- a/src/components/ui/TeamPortrait.tsx
+++ b/src/components/ui/TeamPortrait.tsx
@@ -28,12 +28,12 @@ export default function TeamPortrait({
       >
         <button role="link">
           <div
-            className={`transition-all duration-700 ${
+            className={`transition-all duration-700 motion-reduce:transition-none ${
               activeImage === teamMember
                 ? "md:max-w-[500px] md:max-h-[500px]"
                 : activeImage === otherTeamMember
-                ? "md:max-w-[380px] md:max-h-[380px]"
-                : "md:max-w-[400px] md:max-h-[400px]"
+                  ? "md:max-w-[380px] md:max-h-[380px]"
+                  : "md:max-w-[400px] md:max-h-[400px]"
             }`}
           >
             <Image


### PR DESCRIPTION
Noticed the review marquee was still animating even after setting my accessibility preferences to have no motion - fixed this and in a few other places that weren't applying motion safe animation. 

Centred the marquee of reviews so it looks better when animation disabled.

Added a link button component that is the inverse of the button component (white button white border that turns black on hover) for the CTA link buttons in nav and hero. Better matches our button style we use in contact, let me know what you think.