### PR TITLE
perf: hoist hero loading

### DIFF
--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -7,7 +7,9 @@ import LinkButton from "@/components/ui/LinkButton";
 import nav_items from "@/data/nav_items.json";
 import GoogleReviewBadge from "@/components/GoogleReviewBadge";
 
-const NodeGraph = dynamic(() => import("./NodeGraph"), { ssr: false });
+// Start fetching the three.js chunk at parse time, before hydration completes
+const nodeGraphPromise = import("./NodeGraph");
+const NodeGraph = dynamic(() => nodeGraphPromise, { ssr: false });
 
 export default function Hero() {
   const [seed, setSeed] = useState(0);

--- a/src/components/ui/DesktopProjectImages.tsx
+++ b/src/components/ui/DesktopProjectImages.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useSyncExternalStore } from "react";
 import Image from "next/image";
 import clsx from "clsx";
 import projects from "@/data/projects.json";
@@ -13,6 +14,17 @@ export default function DesktopProjectImages({
   setSelectedProject,
   openModal,
 }: DesktopProjectImagesProps) {
+  // Defer mockups until the page (incl. the hero's three.js chunk) has
+  // loaded, then fetch them all so hover-swapping never shows a part-loaded image
+  const warmImages = useSyncExternalStore(
+    (callback) => {
+      window.addEventListener("load", callback);
+      return () => window.removeEventListener("load", callback);
+    },
+    () => document.readyState === "complete",
+    () => false,
+  );
+
   return (
     <>
       <div className="absolute left-0 top-0 z-30 hidden h-full w-full md:block">
@@ -28,6 +40,7 @@ export default function DesktopProjectImages({
           <Image
             key={`project-image-${index}`}
             fill
+            loading={warmImages ? "eager" : "lazy"}
             sizes="100vw"
             className={clsx(
               "absolute left-0 top-0 -z-50",

--- a/src/components/ui/DesktopProjectImages.tsx
+++ b/src/components/ui/DesktopProjectImages.tsx
@@ -28,7 +28,6 @@ export default function DesktopProjectImages({
           <Image
             key={`project-image-${index}`}
             fill
-            priority
             sizes="100vw"
             className={clsx(
               "absolute left-0 top-0 -z-50",
@@ -39,7 +38,6 @@ export default function DesktopProjectImages({
             }}
             alt={`Mockup of ${project.title}`}
             src={`/projects/${project.src}.jpg`}
-            fetchPriority="low"
           />
         ))}
       </div>

--- a/src/components/ui/MobileProjectImages.tsx
+++ b/src/components/ui/MobileProjectImages.tsx
@@ -33,7 +33,6 @@ export default function MobileProjectImages({
           )}
           {project.renderOnMobile && (
             <Image
-              priority
               sizes="100vw"
               height={300}
               width={380}
@@ -44,7 +43,6 @@ export default function MobileProjectImages({
                 openModal();
               }}
               className="cursor-pointer"
-              fetchPriority="low"
             />
           )}
         </div>


### PR DESCRIPTION
This branch cuts the cold-load time of the hero's three.js node graph, which was taking 3s+ before the 3js stuff appeared.

Profiling the deploy preview showed two compounding causes. The three.js chunk is 311 KB compressed (1.08 MB raw) — larger than every other asset on the page combined — and because it's behind a `dynamic()` import, the browser couldn't even start downloading it until the main bundle had parsed and hydration kicked off the import. Meanwhile, every project mockup carried `priority`, which baked ~20 `<link rel="preload" as="image">` tags into the static head. The preload scanner started those downloads immediately, so the hero's biggest dependency was both requested last and queueing behind a wall of below-the-fold screenshots.

`Hero.tsx` now kicks off `import("./NodeGraph")` at module scope and hands the in-flight promise to `dynamic()`, so the chunk download starts as soon as the page bundle parses rather than after hydration. One trade-off: the chunk now downloads even for `prefers-reduced-motion` users, for whom `NodeGraph` renders nothing — accepted to make the common case faster.

The project images lost their `priority` (and the now-moot `fetchPriority="low"`), falling back to `next/image`'s default lazy loading since they're all below the fold. That alone caused visible pop-in when hovering between mockups in the Work section, because the desktop images are opacity-swapped on hover and were only fetched on viewport approach. So `DesktopProjectImages` now flips them from `lazy` to `eager` once the window `load` event fires — the hero gets the whole connection during initial load, then all nine mockups warm in the background while the user is still on the hero, and they're cached before anyone can hover. If someone scrolls down before `load` fires, they're still lazy, which is no worse than the old behaviour. The page-loaded check uses `useSyncExternalStore`, matching the pattern `NodeGraph` already uses for reduced-motion. Mobile images stay default-lazy since they sit inline in the flow and load as you scroll to them.

This doesn't shrink the three.js chunk itself — dropping `@react-three/postprocessing`/`@react-three/drei` or rewriting the graph as 2D canvas remains the follow-up if cold loads are still too slow. No visual or behavioural changes otherwise.
